### PR TITLE
chore: replace rubinius 3 with rubinius 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ rvm:
   - "2.3"
   - "2.4"
   - "2.5"
+  - "2.6"
   - ruby-head
   - jruby
   - jruby-head
@@ -17,7 +18,7 @@ rvm:
   - rubinius-3
 
 before_install:
-  - "gem install bundler"
+  - "gem install bundler || gem install bundler --version '< 2'"
 
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ rvm:
   - jruby
   - jruby-head
   - jruby-19mode
-  - rubinius-3
+  - rubinius-5
 
 before_install:
   - "gem install bundler || gem install bundler --version '< 2'"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,24 @@
 language: ruby
+sudo: required
+dist: trusty
 script: rake
 rvm:
-  - 1.9.3
-  - 2.0.0
+  - "1.9"
+  - "2.0"
   - "2.1"
   - "2.2"
+  - "2.3"
+  - "2.4"
   - ruby-head
+  - jruby
   - jruby-head
   - jruby-19mode
-  - rbx
+  - rubinius-3
 
 before_install:
   - "gem install bundler"
+
+matrix:
+  allow_failures:
+    - rvm: "ruby-head"
+    - rvm: "jruby-head"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,6 @@ rvm:
   - jruby-head
   - jruby-19mode
   - rbx
+
+before_install:
+  - "gem install bundler"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ rvm:
   - "2.2"
   - "2.3"
   - "2.4"
+  - "2.5"
   - ruby-head
   - jruby
   - jruby-head

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Fix `admin/mkassoc` script.
   See https://github.com/openid/ruby-openid/pull/103
-* Allow spcifying timeout for `OpenID::StandardFetcher` in environment variables.
+* Allow specifying timeout for `OpenID::StandardFetcher` in environment variables.
   See https://github.com/openid/ruby-openid/pull/109
 * Fixed some documentation.
   See https://github.com/openid/ruby-openid/pull/111

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 2.8.0
+
+* Fix `admin/mkassoc` script.
+  See https://github.com/openid/ruby-openid/pull/103
+* Allow spcifying timeout for `OpenID::StandardFetcher` in environment variables.
+  See https://github.com/openid/ruby-openid/pull/109
+* Fixed some documentation.
+  See https://github.com/openid/ruby-openid/pull/111
+* Fixed example server.
+  See https://github.com/openid/ruby-openid/pull/91
+* Fixed tests.
+  See https://github.com/openid/ruby-openid/pull/86
+* Misc. changes to the CI setup.
+  See
+  - https://github.com/openid/ruby-openid/pull/110
+  - https://github.com/openid/ruby-openid/pull/108
+  - https://github.com/openid/ruby-openid/pull/107
+
 ## 2.7.0
 
 * Use RFC 2396 compatible URI parser for trustroot - 7c84ec9ced3ccbdad575e02dbfa81e53b52f909e

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.9.2
+
+* Perform all checks before verifying endpoints.
+  [#126](https://github.com/openid/ruby-openid/pull/126)
+
 ## 2.9.1
 
 * Updated CHANGELOG.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## 2.9.1
+
+* Updated CHANGELOG.md
+
+## 2.9.0
+
+* Remove deprecated `autorequire` from gemspec.
+  [#123](https://github.com/openid/ruby-openid/pull/123)
+* Rescue from `Yadis::XRI::XRIHTTPError` on discovery.
+  [#106](https://github.com/openid/ruby-openid/pull/106)
+* Avoid SSRF for claimed_id request.
+  [#121](https://github.com/openid/ruby-openid/pull/121)
+* Updated documentation.
+  [#115](https://github.com/openid/ruby-openid/pull/115), [#116](https://github.com/openid/ruby-openid/pull/116), [#117](https://github.com/openid/ruby-openid/pull/117), [#118](https://github.com/openid/ruby-openid/pull/118)
+* Reduce warnings output in test runs.
+  [#119](https://github.com/openid/ruby-openid/pull/119)
+* Drop deprecated option from gemspec.
+  [#120](https://github.com/openid/ruby-openid/pull/120)
+* Remove circular require.
+  [#113](https://github.com/openid/ruby-openid/pull/113)
+* Updated Travis CI config with Ruby 2.6
+  [#114](https://github.com/openid/ruby-openid/pull/114)
+* Simplify Bundler require; remove need for extra `:require`.
+  [#112](https://github.com/openid/ruby-openid/pull/112)
+
 ## 2.8.0
 
 * Fix `admin/mkassoc` script.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,21 +1,23 @@
 # Ruby OpenID Library Installation
 
-## Rubygems Installation
+## Install as a gem
 
-Rubygems is a tool for installing ruby libraries and their
-dependancies. If you have rubygems installed, simply:
+`ruby-openid` is distributed on [RubyGems](https://rubygems.org/).
+Install it:
 
     gem install ruby-openid
 
+This is probably what you need.
+
 ## Manual Installation
 
-Unpack the archive and run setup.rb to install:
+Unpack the archive and run `setup.rb` to install:
 
     ruby setup.rb
 
-setup.rb installs the library into your system ruby. If don't want to
+`setup.rb` installs the library into your system ruby. If don't want to
 add openid to you system ruby, you may instead add the `lib` directory of
-the extracted tarball to your RUBYLIB environment variable:
+the extracted tarball to your `RUBYLIB` environment variable:
 
     $ export RUBYLIB=${RUBYLIB}:/path/to/ruby-openid/lib
 
@@ -27,21 +29,13 @@ Make sure everything installed ok:
     irb$> require "openid"
     => true
 
-Or, if you installed via rubygems:
-
-    $> irb
-    irb$> require "rubygems"
-    => true
-    irb$> require_gem "ruby-openid"
-    => true
-
 ## Run the test suite
 
 Go into the test directory and execute the `runtests.rb` script.
 
 ## Next steps
 
-* Run `consumer.rb` in the examples directory.
-* Get started writing your own consumer using OpenID::Consumer
+* Run `consumer.rb` in the `examples/` directory.
+* Get started writing your own consumer using `OpenID::Consumer`
 * Write your own server with `OpenID::Server`
-* Use the `OpenIDLoginGenerator`! Read `example/README.md` for more info.
+* Use the `OpenIDLoginGenerator`! Read `examples/README.md` for more info.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -44,4 +44,4 @@ Go into the test directory and execute the `runtests.rb` script.
 * Run `consumer.rb` in the examples directory.
 * Get started writing your own consumer using OpenID::Consumer
 * Write your own server with `OpenID::Server`
-* Use the `OpenIDLoginGenerator`! Read `example/README` for more info.
+* Use the `OpenIDLoginGenerator`! Read `example/README.md` for more info.

--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ the examples.
 
 ## Homepage
 
-  * [GitHub](http://github.com/openid/ruby-openid)
-  * [Website](http://openid.net/)
+  * GitHub repository: [openid/ruby-openid](http://github.com/openid/ruby-openid)
+  * Homepage: [OpenID.net](http://openid.net/)
 
 ## Community
 
@@ -74,7 +74,7 @@ hesitate to send it to us: [How to contribute](http://openidenabled.com/contribu
 
 Copyright 2006-2012, JanRain, Inc.
 
-Contact openid@janrain.com or visit the [OpenID channel on pibb.com](http://pibb.com/go/openid).
+Contact openid@janrain.com.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Ruby library for verifying and serving OpenID identities.
 
-[![Build Status](https://secure.travis-ci.org/openid/ruby-openid.png)](http://travis-ci.org/openid/ruby-openid)
+[![Build Status](https://secure.travis-ci.org/openid/ruby-openid.svg)](http://travis-ci.org/openid/ruby-openid)
 
 ## Features
 

--- a/admin/mkassoc
+++ b/admin/mkassoc
@@ -1,11 +1,16 @@
 #!/usr/bin/env ruby
 
 require "openid/consumer/associationmanager"
-require "openid/store/memstore"
+require "openid/store/memory"
 
-store = OpenID::MemoryStore.new
+store = OpenID::Store::Memory.new
 ARGV.each do |server_url|
-  mgr = OpenID::Consumer::AssociationManager.new(store, URI.parse(server_url))
+  unless URI::regexp =~ server_url
+    puts "`#{server_url}` will be skipped for invalid URI format."
+    next
+  end
+
+  mgr = OpenID::Consumer::AssociationManager.new(store, server_url)
   puts '=' * 50
   puts "Server: #{server_url}"
   puts mgr.get_association.serialize

--- a/examples/README.md
+++ b/examples/README.md
@@ -3,30 +3,35 @@ OpenID library.  Make sure you have properly installed the library
 before running the examples.  These examples are a great place to
 start in integrating OpenID into your application.
 
-==Rails example
+## Rails example
 
-The rails_openid contains a fully functional OpenID server and relying
+The `rails_openid` directory contains a fully functional OpenID server and relying
 party, and acts as a starting point for implementing your own
 production rails server.  You'll need the latest version of Ruby on
 Rails installed, and then:
 
- cd rails_openid
- ./script/server
+```shell
+cd rails_openid
+./script/server
+```
 
 Open a web browser to http://localhost:3000/ and follow the instructions.
 
 The relevant code to work from when writing your Rails OpenID Relying
 Party is: 
+
   rails_openid/app/controllers/consumer_controller.rb
+
 If you are working on an OpenID provider, check out
+
   rails_openid/app/controllers/server_controller.rb
 
 Since the library and examples are Apache-licensed, don't be shy about 
 copy-and-paste.
 
-==Rails ActiveRecord OpenIDStore plugin
+## Rails ActiveRecord OpenIDStore plugin
 
 For various reasons you may want or need to deploy your ruby openid
-consumer/server using an SQL based store.  The active_record_openid_store 
+consumer/server using an SQL based store.  The `active_record_openid_store` 
 is a plugin that makes using an SQL based store simple.  Follow the
 README inside the plugin's dir for usage.

--- a/lib/openid/consumer.rb
+++ b/lib/openid/consumer.rb
@@ -139,7 +139,7 @@ module OpenID
   #
   # Add an OpenID login field somewhere on your site.  When an OpenID
   # is entered in that field and the form is submitted, it should make
-  # a request to the your site which includes that OpenID URL.
+  # a request to the site that includes that OpenID URL.
   #
   # First, the application should instantiate a Consumer with a
   # session for per-user state and store for shared state using the

--- a/lib/openid/consumer/discovery.rb
+++ b/lib/openid/consumer/discovery.rb
@@ -450,7 +450,7 @@ module OpenID
       services.each { |service_element|
         endpoints += flt.get_service_endpoints(iname, service_element)
       }
-    rescue Yadis::XRDSError => why
+    rescue Yadis::XRDSError, Yadis::XRI::XRIHTTPError => why
       Util.log('xrds error on ' + iname + ': ' + why.to_s)
     end
 

--- a/lib/openid/consumer/idres.rb
+++ b/lib/openid/consumer/idres.rb
@@ -72,9 +72,9 @@ module OpenID
       def id_res
         check_for_fields
         verify_return_to
-        verify_discovery_results
         check_signature
         check_nonce
+        verify_discovery_results
       end
 
       def server_url

--- a/lib/openid/consumer/idres.rb
+++ b/lib/openid/consumer/idres.rb
@@ -71,9 +71,9 @@ module OpenID
       # verified information.
       def id_res
         check_for_fields
-        verify_return_to
         check_signature
         check_nonce
+        verify_return_to
         verify_discovery_results
       end
 

--- a/lib/openid/extensions/ax.rb
+++ b/lib/openid/extensions/ax.rb
@@ -539,9 +539,8 @@ module OpenID
       end
 
       def self.from_success_response(success_response)
-        resp = nil
         ax_args = success_response.message.get_args(NS_URI)
-        resp = ax_args.key?('error') ? new(false, ax_args['error']) : new
+        ax_args.key?('error') ? new(false, ax_args['error']) : new
       end
 
       def succeeded?

--- a/lib/openid/fetchers.rb
+++ b/lib/openid/fetchers.rb
@@ -1,6 +1,6 @@
 require 'net/http'
-require 'openid'
 require 'openid/util'
+require 'openid/version'
 
 begin
   require 'net/https'

--- a/lib/openid/fetchers.rb
+++ b/lib/openid/fetchers.rb
@@ -117,7 +117,7 @@ module OpenID
     USER_AGENT = "ruby-openid/#{OpenID::VERSION} (#{RUBY_PLATFORM})"
 
     REDIRECT_LIMIT = 5
-    TIMEOUT = 60
+    TIMEOUT = ENV['RUBY_OPENID_FETCHER_TIMEOUT'] || 60
 
     attr_accessor :ca_file
     attr_accessor :timeout

--- a/lib/openid/store/filesystem.rb
+++ b/lib/openid/store/filesystem.rb
@@ -230,7 +230,7 @@ module OpenID
       # create a safe filename from a url
       def filename_escape(s)
         s = '' if s.nil?
-        filename_chunks = s.each_char.flat_map {|c|
+        s.each_char.flat_map {|c|
           @@FILENAME_ALLOWED.include?(c) ? c : c.bytes.map {|b|
             "_%02X" % b
           }

--- a/lib/openid/version.rb
+++ b/lib/openid/version.rb
@@ -1,3 +1,3 @@
 module OpenID
-  VERSION = "2.8.0"
+  VERSION = "2.9.1"
 end

--- a/lib/openid/version.rb
+++ b/lib/openid/version.rb
@@ -1,3 +1,3 @@
 module OpenID
-  VERSION = "2.9.1"
+  VERSION = "2.9.2"
 end

--- a/lib/openid/version.rb
+++ b/lib/openid/version.rb
@@ -1,3 +1,3 @@
 module OpenID
-  VERSION = "2.7.0"
+  VERSION = "2.8.0"
 end

--- a/lib/openid/yadis/xri.rb
+++ b/lib/openid/yadis/xri.rb
@@ -1,4 +1,3 @@
-require 'openid/yadis/xrds'
 require 'openid/fetchers'
 
 module OpenID

--- a/lib/ruby-openid.rb
+++ b/lib/ruby-openid.rb
@@ -1,0 +1,1 @@
+require 'openid'

--- a/ruby-openid.gemspec
+++ b/ruby-openid.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |s|
   s.test_files = s.files.grep(%r{^(test|spec|features)/})
 
   # RDoc
-  s.has_rdoc = true
   s.extra_rdoc_files = ['README.md', 'INSTALL.md', 'LICENSE', 'UPGRADE.md']
   s.rdoc_options << '--main' << 'README.md'
 

--- a/ruby-openid.gemspec
+++ b/ruby-openid.gemspec
@@ -15,7 +15,6 @@ Gem::Specification.new do |s|
   files << 'NOTICE' << 'CHANGELOG.md'
   s.files = files.delete_if {|f| f.include?('_darcs') || f.include?('admin')}
   s.require_paths = ['lib']
-  s.autorequire = 'openid'
   s.executables = s.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
   s.test_files = s.files.grep(%r{^(test|spec|features)/})
 

--- a/test/test_associationmanager.rb
+++ b/test/test_associationmanager.rb
@@ -304,7 +304,7 @@ module OpenID
     # server error or is otherwise undecipherable.
     def test_bad_response
       assert_log_matches('Server error when requesting an association') {
-        assert_equal(call_negotiate([mk_message({})]), nil)
+        assert_nil(call_negotiate([mk_message({})]))
       }
     end
 
@@ -320,7 +320,7 @@ module OpenID
                          "Server #{@server_url} responded with unsupported "\
                          "association session but did not supply a fallback."
                          ) {
-        assert_equal(call_negotiate([msg]), nil)
+        assert_nil(call_negotiate([msg]))
       }
 
     end
@@ -337,7 +337,7 @@ module OpenID
                          "Server #{@server_url} responded with unsupported "\
                          "association session but did not supply a fallback."
                          ) {
-        assert_equal(call_negotiate([msg]), nil)
+        assert_nil(call_negotiate([msg]))
       }
     end
 
@@ -357,7 +357,7 @@ module OpenID
 
       assert_log_matches('Unsupported association type',
                          'Server sent unsupported session/association type:') {
-        assert_equal(call_negotiate([msg], negotiator), nil)
+        assert_nil(call_negotiate([msg], negotiator))
       }
     end
 
@@ -388,7 +388,7 @@ module OpenID
 
       assert_log_matches('Unsupported association type',
                          "Server #{@server_url} refused") {
-        assert_equal(call_negotiate([msg, msg]), nil)
+        assert_nil(call_negotiate([msg, msg]))
       }
     end
 
@@ -424,7 +424,7 @@ module OpenID
     def test_bad_response
       assert_log_matches('Server error when requesting an association') {
         response = call_negotiate([mk_message({})])
-        assert_equal(nil, response)
+        assert_nil(response)
       }
     end
 
@@ -436,7 +436,7 @@ module OpenID
 
       assert_log_matches('Server error when requesting an association') {
         response = call_negotiate([msg])
-        assert_equal(nil, response)
+        assert_nil(response)
       }
     end
 
@@ -448,7 +448,7 @@ module OpenID
 
       assert_log_matches('Server error when requesting an association') {
         response = call_negotiate([msg])
-        assert_equal(nil, response)
+        assert_nil(response)
       }
     end
 
@@ -466,7 +466,7 @@ module OpenID
 
       assert_log_matches('Server error when requesting an association') {
         response = call_negotiate([msg])
-        assert_equal(nil, response)
+        assert_nil(response)
       }
     end
 
@@ -482,7 +482,7 @@ module OpenID
 
       assert_log_matches('Server error when requesting an association') {
         response = call_negotiate([msg, assoc])
-        assert_equal(nil, response)
+        assert_nil(response)
       }
     end
 
@@ -818,13 +818,13 @@ module OpenID
 
     def test_not_in_store_no_response
       set_negotiate_response(nil)
-      assert_equal(nil, @assoc_manager.get_association)
+      assert_nil(@assoc_manager.get_association)
     end
 
     def test_not_in_store_negotiate_assoc
       # Not stored beforehand:
       stored_assoc = @store.get_association(@server_url, @assoc.handle)
-      assert_equal(nil, stored_assoc)
+      assert_nil(stored_assoc)
 
       # Returned from associate call:
       set_negotiate_response(@assoc)
@@ -898,7 +898,7 @@ module OpenID
     def test_missing_fields
       @message.del_arg(OPENID_NS, 'assoc_type')
       assert_log_matches('Missing required par') {
-        assert_equal(nil, make_request)
+        assert_nil(make_request)
       }
     end
 
@@ -907,7 +907,7 @@ module OpenID
     def test_protocol_error
       @message.set_arg(OPENID_NS, 'expires_in', 'goats')
       assert_log_matches('Protocol error processing') {
-        assert_equal(nil, make_request)
+        assert_nil(make_request)
       }
     end
   end

--- a/test/test_ax.rb
+++ b/test/test_ax.rb
@@ -47,7 +47,7 @@ module OpenID
         assert_equal(type_uri, ainfo.type_uri)
         assert_equal(1, ainfo.count)
         assert_equal(false, ainfo.required)
-        assert_equal(nil, ainfo.ns_alias)
+        assert_nil(ainfo.ns_alias)
       end
     end
 
@@ -234,7 +234,7 @@ module OpenID
 
       def test_construct
         assert_equal({}, @msg.requested_attributes)
-        assert_equal(nil, @msg.update_url)
+        assert_nil(@msg.update_url)
 
         msg = FetchRequest.new('hailstorm')
         assert_equal({}, msg.requested_attributes)
@@ -494,7 +494,7 @@ module OpenID
       end
 
       def test_construct
-        assert_equal(nil, @msg.update_url)
+        assert_nil(@msg.update_url)
         assert_equal({}, @msg.data)
       end
 
@@ -541,7 +541,7 @@ module OpenID
       end
 
       def test_get_extension_args_single_value_response
-        # Single values do NOT have a count, and 
+        # Single values do NOT have a count, and
         # do not use the array extension
         eargs = {
           'mode' => 'fetch_response',
@@ -585,7 +585,7 @@ module OpenID
       end
 
       def test_get_single_none
-        assert_equal(nil, @msg.get_single(@type_a))
+        assert_nil(@msg.get_single(@type_a))
       end
 
       def test_get_single_extra

--- a/test/test_consumer.rb
+++ b/test/test_consumer.rb
@@ -16,7 +16,7 @@ module OpenID
           assert_equal(:endpoint, ep)
           consumer.send(:cleanup_last_requested_endpoint)
           ep = consumer.send(:last_requested_endpoint)
-          assert_equal(nil, ep)
+          assert_nil(ep)
         end
       end
 

--- a/test/test_discover.rb
+++ b/test/test_discover.rb
@@ -724,8 +724,8 @@ module OpenID
     end
 
     def test_noIdentifiers
-      assert_equal(@endpoint.get_local_id, nil)
-      assert_equal(@endpoint.claimed_id, nil)
+      assert_nil(@endpoint.get_local_id)
+      assert_nil(@endpoint.claimed_id)
     end
 
     def test_compatibility
@@ -733,7 +733,7 @@ module OpenID
     end
 
     def test_canonical_id
-      assert_equal(@endpoint.canonical_id, nil)
+      assert_nil(@endpoint.canonical_id)
     end
 
     def test_serverURL

--- a/test/test_discovery_manager.rb
+++ b/test/test_discovery_manager.rb
@@ -21,8 +21,8 @@ module OpenID
       assert_equal(@disco_services.next, @services[1])
       assert_equal(@disco_services.current, @services[1])
 
-      assert_equal(@disco_services.next, nil)
-      assert_equal(@disco_services.current, nil)
+      assert_nil(@disco_services.next)
+      assert_nil(@disco_services.current)
     end
 
     def test_for_url
@@ -84,7 +84,7 @@ module OpenID
     end
 
     def test_get_next_service
-      assert_equal(@session[@key], nil)
+      assert_nil(@session[@key])
 
       next_service = @manager.get_next_service {
         [@yadis_url, ["one", "two", "three"]]
@@ -123,24 +123,24 @@ module OpenID
         ["unused", []]
       }
 
-      assert_equal(result, nil)
+      assert_nil(result)
     end
 
     def test_cleanup
       # With no preexisting manager, cleanup() returns nil.
-      assert_equal(@manager.cleanup, nil)
+      assert_nil(@manager.cleanup)
 
       # With a manager, it returns the manager's current service.
       disco = Consumer::DiscoveredServices.new(@url, @yadis_url, ["one", "two"])
 
       @session[@key] = disco
-      assert_equal(@manager.cleanup, nil)
-      assert_equal(@session[@key], nil)
+      assert_nil(@manager.cleanup)
+      assert_nil(@session[@key])
 
       disco.next
       @session[@key] = disco
       assert_equal(@manager.cleanup, "one")
-      assert_equal(@session[@key], nil)
+      assert_nil(@session[@key])
 
       # The force parameter should be passed through to get_manager
       # and destroy_manager.
@@ -178,7 +178,7 @@ module OpenID
       disco2 = Consumer::DiscoveredServices.new("http://not.this.url.com/",
                                                 "http://other.yadis.url/", ["one"])
       @session[@key] = disco2
-      assert_equal(@manager.get_manager, nil)
+      assert_nil(@manager.get_manager)
       assert_equal(@manager.get_manager(true), disco2)
     end
 

--- a/test/test_message.rb
+++ b/test/test_message.rb
@@ -10,12 +10,14 @@ module OpenID
     # Tests a standard set of behaviors of Message.get_arg with
     # variations on handling defaults.
     def get_arg_tests(ns, key, expected=nil)
-      assert_equal(expected, @m.get_arg(ns, key))
-
       if expected.nil?
+        assert_nil(@m.get_arg(ns, key))
+
         assert_equal(@m.get_arg(ns, key, :a_default), :a_default)
         assert_raises(Message::KeyNotFound) { @m.get_arg(ns, key, NO_DEFAULT) }
       else
+        assert_equal(expected, @m.get_arg(ns, key))
+
         assert_equal(@m.get_arg(ns, key, :a_default), expected)
         assert_equal(@m.get_arg(ns, key, NO_DEFAULT), expected)
       end
@@ -73,7 +75,7 @@ module OpenID
     end
 
     def test_get_openid
-      assert_equal(nil, @m.get_openid_namespace)
+      assert_nil(@m.get_openid_namespace)
     end
 
     def test_get_key_openid
@@ -87,15 +89,15 @@ module OpenID
     end
 
     def test_get_key_ns1
-      assert_equal(nil, @m.get_key(OPENID1_NS, 'foo'))
+      assert_nil(@m.get_key(OPENID1_NS, 'foo'))
     end
 
     def test_get_key_ns2
-      assert_equal(nil, @m.get_key(OPENID2_NS, 'foo'))
+      assert_nil(@m.get_key(OPENID2_NS, 'foo'))
     end
 
     def test_get_key_ns3
-      assert_equal(nil, @m.get_key('urn:something-special', 'foo'))
+      assert_nil(@m.get_key('urn:something-special', 'foo'))
     end
 
     def test_has_key
@@ -202,7 +204,7 @@ module OpenID
     def _test_set_arg_ns(ns)
       key = 'Camper Van Beethoven'
       value = 'David Lowery'
-      assert_equal(nil, @m.get_arg(ns, key))
+      assert_nil(@m.get_arg(ns, key))
       @m.set_arg(ns, key, value)
       assert_equal(value, @m.get_arg(ns, key))
     end
@@ -228,7 +230,7 @@ module OpenID
 
     def _test_del_arg_ns(ns)
       key = 'Fleeting Joys'
-      assert_equal(nil, @m.del_arg(ns, key))
+      assert_nil(@m.del_arg(ns, key))
     end
 
     def test_del_arg_bare
@@ -362,11 +364,11 @@ module OpenID
     end
 
     def test_get_key_ns2
-      assert_equal(nil, @m.get_key(OPENID2_NS, 'mode'))
+      assert_nil(@m.get_key(OPENID2_NS, 'mode'))
     end
 
     def test_get_key_ns3
-      assert_equal(nil, @m.get_key('urn:xxx', 'mode'))
+      assert_nil(@m.get_key('urn:xxx', 'mode'))
     end
 
     def test_has_key
@@ -461,7 +463,7 @@ module OpenID
     def _test_set_arg_ns(ns)
       key = 'awesometown'
       value = 'funny'
-      assert_equal(nil, @m.get_arg(ns,key))
+      assert_nil(@m.get_arg(ns,key))
       @m.set_arg(ns, key, value)
       assert_equal(value, @m.get_arg(ns,key))
     end
@@ -478,7 +480,7 @@ module OpenID
       @m.set_arg(ns, key, value)
       assert_equal(value, @m.get_arg(ns,key))
       @m.del_arg(ns,key)
-      assert_equal(nil, @m.get_arg(ns,key))
+      assert_nil(@m.get_arg(ns,key))
     end
 
     def test_del_arg; _test_del_arg_ns(OPENID_NS); end
@@ -702,7 +704,7 @@ module OpenID
     end
 
     def test_get_key_ns1
-      assert_equal(nil, @m.get_key(OPENID1_NS, 'mode'))
+      assert_nil(@m.get_key(OPENID1_NS, 'mode'))
     end
 
     def test_get_key_ns2
@@ -710,7 +712,7 @@ module OpenID
     end
 
     def test_get_key_ns3
-      assert_equal(nil, @m.get_key('urn:xxx', 'mode'))
+      assert_nil(@m.get_key('urn:xxx', 'mode'))
     end
 
     def test_has_key_openid
@@ -739,11 +741,11 @@ module OpenID
     end
 
     def test_get_arg_bare
-      assert_equal(nil, @m.get_arg(BARE_NS,'mode'))
+      assert_nil(@m.get_arg(BARE_NS,'mode'))
     end
 
     def test_get_arg_ns1
-      assert_equal(nil, @m.get_arg(OPENID1_NS,'mode'))
+      assert_nil(@m.get_arg(OPENID1_NS,'mode'))
     end
 
     def test_get_arg_ns2
@@ -751,7 +753,7 @@ module OpenID
     end
 
     def test_get_arg_ns3
-      assert_equal(nil, @m.get_arg('urn:bananastand','mode'))
+      assert_nil(@m.get_arg('urn:bananastand','mode'))
     end
 
     def test_get_args_openid
@@ -813,7 +815,7 @@ module OpenID
     def _test_set_arg_ns(ns)
       key = "logan's"
       value = "run"
-      assert_equal(nil, @m.get_arg(ns,key))
+      assert_nil(@m.get_arg(ns,key))
       @m.set_arg(ns, key, value)
       assert_equal(value, @m.get_arg(ns,key))
     end
@@ -851,11 +853,11 @@ module OpenID
     def _test_del_arg_ns(ns)
       key = 'no'
       value = 'socks'
-      assert_equal(nil, @m.get_arg(ns, key))
+      assert_nil(@m.get_arg(ns, key))
       @m.set_arg(ns, key, value)
       assert_equal(value, @m.get_arg(ns, key))
       @m.del_arg(ns, key)
-      assert_equal(nil, @m.get_arg(ns, key))
+      assert_nil(@m.get_arg(ns, key))
     end
 
     def test_del_arg_openid; _test_del_arg_ns(OPENID_NS); end

--- a/test/test_oauth.rb
+++ b/test/test_oauth.rb
@@ -143,7 +143,6 @@ module OpenID
           'mode' => 'id_res',
           'ns' => OPENID2_NS,
           'ns.oauth' => OAuth::NS_URI,
-          'ns.oauth' => OAuth::NS_URI,
           'oauth.request_token' => 'REQUESTTOKEN',
           'oauth.scope' => "http://sample.com/some_scope"
         })

--- a/test/test_pape.rb
+++ b/test/test_pape.rb
@@ -13,7 +13,7 @@ module OpenID
 
       def test_construct
         assert_equal([], @req.preferred_auth_policies)
-        assert_equal(nil, @req.max_auth_age)
+        assert_nil(@req.max_auth_age)
         assert_equal('pape', @req.ns_alias)
 
         req2 = PAPE::Request.new([PAPE::AUTH_MULTI_FACTOR], 1000)
@@ -53,7 +53,7 @@ module OpenID
 
       def test_parse_extension_args_empty
         @req.parse_extension_args({})
-        assert_equal(nil, @req.max_auth_age)
+        assert_nil(@req.max_auth_age)
         assert_equal([], @req.preferred_auth_policies)
       end
 
@@ -110,9 +110,9 @@ module OpenID
 
       def test_construct
         assert_equal([], @req.auth_policies)
-        assert_equal(nil, @req.auth_time)
+        assert_nil(@req.auth_time)
         assert_equal('pape', @req.ns_alias)
-        assert_equal(nil, @req.nist_auth_level)
+        assert_nil(@req.nist_auth_level)
 
         req2 = PAPE::Response.new([PAPE::AUTH_MULTI_FACTOR], "1983-11-05T12:30:24Z", 3)
         assert_equal([PAPE::AUTH_MULTI_FACTOR], req2.auth_policies)
@@ -168,7 +168,7 @@ module OpenID
 
       def test_parse_extension_args_empty
         @req.parse_extension_args({})
-        assert_equal(nil, @req.auth_time)
+        assert_nil(@req.auth_time)
         assert_equal([], @req.auth_policies)
       end
 
@@ -205,8 +205,8 @@ module OpenID
                 'nist_auth_level' => 'some'}
         @req.parse_extension_args(args)
         assert_equal(['http://foo','http://bar'], @req.auth_policies)
-        assert_equal(nil, @req.auth_time)
-        assert_equal(nil, @req.nist_auth_level)
+        assert_nil(@req.auth_time)
+        assert_nil(@req.nist_auth_level)
       end
 
 

--- a/test/test_responses.rb
+++ b/test/test_responses.rb
@@ -55,7 +55,7 @@ module OpenID
           # Not all args in this NS are signed, so expect nil when
           # asking for them.
           utargs = resp.extension_response('urn:unittest', true)
-          assert_equal(nil, utargs)
+          assert_nil(utargs)
         end
       end
     end

--- a/test/test_server.rb
+++ b/test/test_server.rb
@@ -142,7 +142,7 @@ module OpenID
     def test_no_message
       e = Server::ProtocolError.new(nil, "no message")
       assert(e.get_return_to.nil?)
-      assert_equal(e.which_encoding, nil)
+      assert_nil(e.which_encoding)
     end
 
     def test_which_encoding_no_message
@@ -167,7 +167,7 @@ module OpenID
     def test_none
       args = {}
       r = @decode.call(args)
-      assert_equal(r, nil)
+      assert_nil(r)
     end
 
     def test_irrelevant
@@ -350,7 +350,7 @@ module OpenID
       assert(r.is_a?(Server::CheckIDRequest))
       assert_equal(r.mode, "checkid_setup")
       assert_equal(r.immediate, false)
-      assert_equal(r.identity, nil)
+      assert_nil(r.identity)
       assert_equal(r.trust_root, @tr_url)
       assert_equal(r.return_to, @rt_url)
     end
@@ -1896,9 +1896,9 @@ module OpenID
       response = @request.answer_unsupported(message)
       rfg = lambda { |f| response.fields.get_arg(OPENID_NS, f) }
       assert_equal(rfg.call('error_code'), 'unsupported-type')
-      assert_equal(rfg.call('assoc_type'), nil)
+      assert_nil(rfg.call('assoc_type'))
       assert_equal(rfg.call('error'), message)
-      assert_equal(rfg.call('session_type'), nil)
+      assert_nil(rfg.call('session_type'))
     end
 
     def test_openid1_unsupported_explode
@@ -2323,8 +2323,7 @@ module OpenID
     def test_getAssocInvalid
       ah = 'no-such-handle'
       silence_logging {
-        assert_equal(
-                     @signatory.get_association(ah, false), nil)
+        assert_nil(@signatory.get_association(ah, false))
       }
       # assert(!@messages, @messages)
     end
@@ -2333,8 +2332,7 @@ module OpenID
       # getAssociation(dumb=False) cannot get a dumb assoc
       assoc_handle = makeAssoc(true)
       silence_logging {
-        assert_equal(
-                     @signatory.get_association(assoc_handle, false), nil)
+        assert_nil(@signatory.get_association(assoc_handle, false))
       }
       # @failIf(@messages, @messages)
     end
@@ -2348,8 +2346,7 @@ module OpenID
       #   MAC keys.
       assoc_handle = makeAssoc(false)
       silence_logging {
-        assert_equal(
-                     @signatory.get_association(assoc_handle, true), nil)
+        assert_nil(@signatory.get_association(assoc_handle, true))
       }
       # @failIf(@messages, @messages)
     end

--- a/test/test_sreg.rb
+++ b/test/test_sreg.rb
@@ -154,7 +154,7 @@ module OpenID
           req = Request.new
           assert_equal([], req.optional)
           assert_equal([], req.required)
-          assert_equal(nil, req.policy_url)
+          assert_nil(req.policy_url)
           assert_equal(NS_URI, req.ns_uri)
         end
 
@@ -476,4 +476,3 @@ module OpenID
     end
   end
 end
-

--- a/test/test_stores.rb
+++ b/test/test_stores.rb
@@ -218,7 +218,7 @@ module OpenID
       include StoreTestCase
 
       def setup
-        raise "filestoretest directory exists" if File.exists?('filestoretest')
+        raise "filestoretest directory exists" if File.exist?('filestoretest')
         @store = Filesystem.new('filestoretest')
       end
 

--- a/test/test_yadis_discovery.rb
+++ b/test/test_yadis_discovery.rb
@@ -201,7 +201,7 @@ module OpenID
       def test_no_content_type
         with_fetcher(NoContentTypeFetcher.new) do
           result = Yadis.discover("http://bogus")
-          assert_equal(nil, result.content_type)
+          assert_nil(result.content_type)
         end
       end
 


### PR DESCRIPTION
Instead of just removing the rubinius test run, replace it with a newer version. let's see if this runs successfully. 